### PR TITLE
Those handlers are taking over the post request of GridWeb's ajax cal…

### DIFF
--- a/Examples.GridWeb/CSharp/Web.config
+++ b/Examples.GridWeb/CSharp/Web.config
@@ -77,13 +77,6 @@
     </pages>
   </system.web>
   <system.webServer>
-    <handlers>
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
-      <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG,PUT,DELETE,PATCH,OPTIONS" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers>
+    
   </system.webServer>
 </configuration>


### PR DESCRIPTION
…l, so we have removed these settings in <system.webServer> ...</system.webServer>